### PR TITLE
Set self-signed private key to be read/write by root user only

### DIFF
--- a/lib/flight_cert/commands/cert_gen.rb
+++ b/lib/flight_cert/commands/cert_gen.rb
@@ -169,6 +169,7 @@ module FlightCert
         FileUtils.mkdir_p Flight.config.selfsigned_dir
         File.write        Flight.config.selfsigned_fullchain, builder.to_fullchain
         File.write        Flight.config.selfsigned_privkey,   builder.key.to_s
+        File.chmod 0600,  Flight.config.selfsigned_privkey
         puts 'Certificate generated.'
       end
 


### PR DESCRIPTION
This PR adds an extra method call when generating self-signed certificates to make sure that the private key file permissions are 0600 (i.e. only readable/writable by the file owner and root user). As part of this PR, the file permissions for Let's Encrypt certificates were double-checked to ensure that they matched the desired permissions as self-signed certificates.